### PR TITLE
Fix code scanning alert no. 47: Information exposure through an exception

### DIFF
--- a/web/api/views.py
+++ b/web/api/views.py
@@ -1556,7 +1556,8 @@ class CMSDetector(APIView):
 					return Response(response)
 			return Response(response)
 		except Exception as e:
-			response = {'status': False, 'message': str(e)}
+			logger.exception("An error occurred while detecting CMS")
+			response = {'status': False, 'message': 'An internal error has occurred!'}
 			return Response(response)
 
 


### PR DESCRIPTION
Fixes [https://github.com/khulnasoft/reconpoint/security/code-scanning/47](https://github.com/khulnasoft/reconpoint/security/code-scanning/47)

To fix the problem, we need to ensure that detailed exception information is not exposed to the end user. Instead, we should log the exception details on the server and return a generic error message to the user. This can be achieved by modifying the exception handling block to log the error and return a generic response.

- Modify the exception handling block in the `CMSDetector` class to log the exception using the `logger` and return a generic error message.
- Ensure that the logging captures the full stack trace for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
