### PR TITLE
Fix code scanning alert no. 15: DOM text reinterpreted as HTML

### DIFF
--- a/web/static/custom/toolbox.js
+++ b/web/static/custom/toolbox.js
@@ -1,3 +1,12 @@
+function escapeHtml(unsafe) {
+    return unsafe
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
+
 function show_whois_lookup_modal(){
 	$('#modal_title').html('WHOIS Lookup');
 	$('#modal-content').empty();
@@ -73,7 +82,7 @@ function cms_detector_api_call(url){
 	}).then(response => response.json()).then(function(response) {
 		if (response.status) {
 			swal.close();
-			$('#modal_title').html('CMS Details for ' + url);
+			$('#modal_title').html('CMS Details for ' + escapeHtml(url));
 			$('#modal-content').empty();
 
 			content = `


### PR DESCRIPTION
Fixes [https://github.com/khulnasoft/reconpoint/security/code-scanning/15](https://github.com/khulnasoft/reconpoint/security/code-scanning/15)

To fix the problem, we need to ensure that the `url` is properly escaped before being inserted into the HTML content. This can be achieved by using a function that escapes HTML special characters, thereby preventing any potential XSS attacks.

- We will create a utility function `escapeHtml` that will escape special HTML characters.
- We will use this function to escape the `url` before inserting it into the HTML content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
